### PR TITLE
Initial attempt in adding docker as a build container.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/tools/.wine

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,13 @@ LOG_DIR		?= $(OUTPUT_DIR)/logs
 # Path to the keil binaries
 KEIL_PATH	?= ~/.wine/drive_c/Keil_v5/C51/BIN
 
-WINE_BIN	?= /usr/local/bin/wine
-
 # Assembler and linker binaries
 AX51_BIN	= $(KEIL_PATH)/AX51.exe
 LX51_BIN	= $(KEIL_PATH)/LX51.exe
 OX51_BIN	= $(KEIL_PATH)/Ohx51.exe
-AX51		= $(WINE_BIN) $(AX51_BIN)
-LX51		= $(WINE_BIN) $(LX51_BIN)
-OX51		= $(WINE_BIN) $(OX51_BIN)
+AX51		= wine $(AX51_BIN)
+LX51		= wine $(LX51_BIN)
+OX51		= wine $(OX51_BIN)
 
 # Set up flags
 #AX51_FLAGS	= DEBUG NOMOD51

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ HEX_DIR		?= $(OUTPUT_DIR)/hex
 LOG_DIR		?= $(OUTPUT_DIR)/logs
 
 # Path to the keil binaries
-KEIL_PATH	?= ~/Downloads/keil_8051/9.60/BIN
+KEIL_PATH	?= ~/.wine/drive_c/Keil_v5/C51/BIN
 
 WINE_BIN	?= /usr/local/bin/wine
 

--- a/README.md
+++ b/README.md
@@ -64,26 +64,18 @@ If you have problems, suggestions or other feedback you can open an [issue](http
 
 Join the new [Discord server](https://discord.gg/phAmtxnMMN) to ask questions and discuss Bluejay.
 
-### IDE
-To install an IDE and toolchain, use [SILABS Simplicity Studio](https://www.silabs.com/developers/simplicity-studio).
-
-After installing and starting Simplicity, choose *"Install"* from the toolbar, then *"Manage installed packages"* from there select the *"SDK"* tab and install the 8051 SDK. From the *"Toolchains"* tab install the *"Keil 8051 Toolchain"*.
-
-#### Obtaining license key
-You now only have the evaluation license for the Keil toolchain, you need to get a license for the full version. Go to "Help" -> "Licensing" -> "Keil 8051". From there you need to follow the link to a from after which you will be sent a license key for the full version of the Keil toolchain.
-
-### Registering via WINE
-If you only want compiler and linker, [download the C51 package from Keil](https://www.keil.com/demo/eval/c51.htm). Run it with wine:
+### Obtaining the toolchain
+To obtain the toolchain, [download the C51 package from Keil](https://www.keil.com/demo/eval/c51.htm). Run it with wine:
 
     wine c51v960a.exe
 
-This will install toolchain and uVision. To obtain a license key you need to run uVision in order to get your Computer ID.
+This will install toolchain and uVision. To obtain a license key (which you will need in order to link files above a certain size) you will have to run uVision in order to get your Computer ID.
 
     wine ~/.wine/drive_c/Keil_v5/UV4/UV4.exe
 
 Go to "File" -> "License Management" note your "Computer ID".
 
-With that, you can request a licence key on the [Keil license installation page](https://www.keil.com/license/install.htm?P=X9F3Y-I8FIW-TWSZ0). In the CID field you need to enter the Computer ID which uVision showed you in the previous step.
+With this information, you can request a licence key on the [Keil license installation page](https://www.keil.com/license/install.htm?P=X9F3Y-I8FIW-TWSZ0). In the CID field you need to enter the Computer ID which uVision showed you in the previous step.
 
 The license ID will be sent to you via E-Mail, once received you paste it into the LIC field, press "Add LIC" and you are done.
 
@@ -102,7 +94,7 @@ A build script is provided, it will build all targets if no further parameters a
 
 or a specific target if you chose to:
 
-    ./build.sh -l A -m H -d 0 -p96
+    ./build.sh -l A -m H -d 0 -p 96
 
 If a specific target is chosen, all parameters need to be provided: layout, mcu, deadtime and pwm
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,45 @@ Any help you can provide is greatly appreciated!
 If you have problems, suggestions or other feedback you can open an [issue](https://github.com/mathiasvr/bluejay/issues).
 
 Join the new [Discord server](https://discord.gg/phAmtxnMMN) to ask questions and discuss Bluejay.
+
+### IDE
+To install an IDE and toolchain, use [SILABS Simplicity Studio](https://www.silabs.com/developers/simplicity-studio).
+
+After installing and starting Simplicity, choose *"Install"* from the toolbar, then *"Manage installed packages"* from there select the *"SDK"* tab and install the 8051 SDK. From the *"Toolchains"* tab install the *"Keil 8051 Toolchain"*.
+
+#### Obtaining license key
+You now only have the evaluation license for the Keil toolchain, you need to get a license for the full version. Go to "Help" -> "Licensing" -> "Keil 8051". From there you need to follow the link to a from after which you will be sent a license key for the full version of the Keil toolchain.
+
+### Registering via WINE
+If you only want compiler and linker, [download the C51 package from Keil](https://www.keil.com/demo/eval/c51.htm). Run it with wine:
+
+    wine c51v960a.exe
+
+This will install toolchain and uVision. To obtain a license key you need to run uVision in order to get your Computer ID.
+
+    wine ~/.wine/drive_c/Keil_v5/UV4/UV4.exe
+
+Go to "File" -> "License Management" note your "Computer ID".
+
+With that, you can request a licence key on the [Keil license installation page](https://www.keil.com/license/install.htm?P=X9F3Y-I8FIW-TWSZ0). In the CID field you need to enter the Computer ID which uVision showed you in the previous step.
+
+The license ID will be sent to you via E-Mail, once received you paste it into the LIC field, press "Add LIC" and you are done.
+
+### Building
+For your convenience a Docker Image is provided that will set up the toolchain. For this to work you need to have completed the step [Registering via Wine](#registering-via-wine) and your ```.wine``` directory has to be copied to the tools directory.
+
+To build the docker image [install docker](https://docs.docker.com/engine/install) and from the tools directory run:
+
+    docker build -t bluejay-build .
+
+A build script is provided, it will build all targets if no further parameters are provided:
+
+    ./build.sh
+
+or a specific target if you chose to:
+
+    ./build.sh -l A -m H -d 0 -p96
+
+If a specific target is chosen, all parameters need to be provided: layout, mcu, deadtime and pwm
+
+The source from the projects root is used to build the firmware.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The license ID will be sent to you via E-Mail, once received you paste it into t
 ### Building
 For your convenience a Docker Image is provided that will set up the toolchain. For this to work you need to have completed the step [Registering via Wine](#registering-via-wine) and your ```.wine``` directory has to be copied to the tools directory.
 
+> The .wine directory can be deleted from the tools directory after the docker image has been created.
+
 To build the docker image [install docker](https://docs.docker.com/engine/install) and from the tools directory run:
 
     docker build -t bluejay-build .

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:10
+RUN dpkg --add-architecture i386
+RUN apt-get update
+RUN apt-get install -y wget wine wine32 make
+RUN ln -s /usr/bin/wine /usr/local/bin/wine
+COPY .wine /root/.wine

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -2,5 +2,6 @@ FROM debian:10
 RUN dpkg --add-architecture i386
 RUN apt-get update
 RUN apt-get install -y wget wine wine32 make
-RUN ln -s /usr/bin/wine /usr/local/bin/wine
-COPY .wine /root/.wine
+COPY .wine/user.reg /root/.wine/user.reg
+COPY .wine/system.reg /root/.wine/system.reg
+COPY .wine/drive_c/Keil_v5 /root/.wine/drive_c/Keil_v5

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+source_path=$(dirname $(pwd))
+
+usage() {
+  echo "Usage: $0 [-l <A-W>] [-m <H|L>] [-d <integer>] [-p <24|48|96>]" 1>&2
+  exit 1
+}
+
+while getopts ":l:m:d:p:" o; do
+  case "${o}" in
+    l)
+      layout=${OPTARG}
+      ;;
+    m)
+      mcu=${OPTARG}
+      ((mcu == 'H' || mcu == 'L')) || usage
+      ;;
+    d)
+      deadtime=${OPTARG}
+      ;;
+    p)
+      pwm=${OPTARG}
+      ((pwm == 24 || pwm == 48 || pwm == 96)) || usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${layout}" ] && [ -z "${mcu}" ] && [ -z "${deadtime}" ] && [ -z "${pwm}" ]; then
+  # All optional parameters are missing
+  target="all"
+  params="all"
+else
+  if [ -z "${layout}" ] || [ -z "${mcu}" ] || [ -z "${deadtime}" ] || [ -z "${pwm}" ]; then
+    # If one optional parameter is given, all are needed
+    usage
+  fi
+
+  target="${layout}_${mcu}_${deadtime}_${pwm}"
+  params="LAYOUT=${layout} MCU=${mcu} DEADTIME=${deadtime} PWM=${pwm}"
+fi
+
+echo "Building ${target}"
+
+docker run -t -d --name bluejay-$target --mount type=bind,source="$source_path",target=/root/source bluejay-build:latest
+docker exec bluejay-$target sh -c "cd /root/source && make $params"
+docker stop bluejay-$target > /dev/null
+docker rm bluejay-$target > /dev/null


### PR DESCRIPTION
It turns out that working with the Keil toolchain is quite painfull. Each user requires his own license. Although the license being free, we can't just provide a pre-populated tool chain.
Developers will need to properly register their Keil toolchain and can then use the docker image for building. Right now the docker image is pretty dumb, since the user has to do a lot of stuff by himself.
A build script was added to help building all or single targets via docker.

Work in progress - feedback welcome.