### PR TITLE
build: Use latest git tag as default version when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Current version
-VERSION		?= $(shell git describe --tags --abbrev=0 | tr 'a-z' 'A-Z')
+TAG			:= $(shell git describe --tags --abbrev=0)
+VERSION		?= $(TAG)
 
 # Target parameters
 LAYOUTS		= A B C D E F G H I J K L M N O P Q R S T U V W Z
@@ -93,7 +94,7 @@ all : $(HEX_TARGETS)
 	@echo "\nbuild finished. built $(shell ls -Aq $(HEX_DIR) | wc -l) hex targets\n"
 
 $(OUTPUT_DIR)/%.OMF : $(OUTPUT_DIR)/%.OBJ
-	$(eval MAP := $(OUTPUT_DIR)/$(basename $(notdir $@)).MAP)
+	$(eval MAP := $(OUTPUT_DIR)/$(shell echo $(basename $(notdir $@)).MAP | tr 'a-z' 'A-Z'))
 	@echo "LX51 : linking $< to $@"
 #	Linking should produce exactly 1 warning
 	@$(LX51) "$<" TO "$@" "$(LX51_FLAGS)" > /dev/null 2>&1; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current version
-VERSION		?= v0.10
+VERSION		?= $(shell git describe --tags --abbrev=0 | tr 'a-z' 'A-Z')
 
 # Target parameters
 LAYOUTS		= A B C D E F G H I J K L M N O P Q R S T U V W Z

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10
 RUN dpkg --add-architecture i386
 RUN apt-get update
-RUN apt-get install -y wget wine wine32 make
+RUN apt-get install -y wget wine wine32 make git
 COPY .wine/user.reg /root/.wine/user.reg
 COPY .wine/system.reg /root/.wine/system.reg
 COPY .wine/drive_c/Keil_v5 /root/.wine/drive_c/Keil_v5


### PR DESCRIPTION
How about this? This will use the latest, uppercased tag from git.