### PR TITLE
Optimize and fix commutation timing calculations

### DIFF
--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -2100,9 +2100,7 @@ adjust_comm_timing:
 
 	inc	Temp8					; Increase timing (if metric 130 or above)
 
-	clr	C
-	mov	A, Demag_Detected_Metric
-	subb	A, #160
+	subb	A, #30
 	jc	($+3)
 
 	inc	Temp8					; Increase timing again (if metric 160 or above)

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -2067,6 +2067,8 @@ ENDIF
 	rrc	A
 	mov	Temp5, A
 
+	mov	Wt_Zc_Scan_Start_L, Temp5	; Set 7.5deg time for zero cross scan delay
+	mov	Wt_Zc_Scan_Start_H, Temp6
 	mov	Wt_Zc_Tout_Start_L, Temp1	; Set 15deg time for zero cross scan timeout
 	mov	Wt_Zc_Tout_Start_H, Temp2
 
@@ -2117,8 +2119,6 @@ store_times_increase:
 	mov	Wt_Comm_Start_H, Temp4
 	mov	Wt_Adv_Start_L, Temp1		; New commutation advance time (~15deg nominal)
 	mov	Wt_Adv_Start_H, Temp2
-	mov	Wt_Zc_Scan_Start_L, Temp5	; Use this value for zero cross scan delay (7.5deg)
-	mov	Wt_Zc_Scan_Start_H, Temp6
 	sjmp	calc_new_wait_times_exit
 
 store_times_decrease:
@@ -2126,8 +2126,6 @@ store_times_decrease:
 	mov	Wt_Comm_Start_H, Temp2
 	mov	Wt_Adv_Start_L, Temp3		; New commutation advance time (~15deg nominal)
 	mov	Wt_Adv_Start_H, Temp4
-	mov	Wt_Zc_Scan_Start_L, Temp5	; Use this value for zero cross scan delay (7.5deg)
-	mov	Wt_Zc_Scan_Start_H, Temp6
 
 	; Set very short delays for all but advance time during startup, in order to widen zero cross capture range
 	jnb	Flag_Startup_Phase, calc_new_wait_times_exit
@@ -2149,6 +2147,7 @@ calc_new_wait_times_fast:
 	rrc	A						; Divide by 2
 	mov	Temp5, A
 
+	mov	Wt_Zc_Scan_Start_L, Temp5	; Use this value for zero cross scan delay (7.5deg)
 	mov	Wt_Zc_Tout_Start_L, Temp1	; Set 15deg time for zero cross scan timeout
 
 	clr	C
@@ -2182,13 +2181,11 @@ store_times_up_or_down_fast:
 store_times_increase_fast:
 	mov	Wt_Comm_Start_L, Temp3		; Now commutation time (~60deg) divided by 4 (~15deg nominal)
 	mov	Wt_Adv_Start_L, Temp1		; New commutation advance time (~15deg nominal)
-	mov	Wt_Zc_Scan_Start_L, Temp5	; Use this value for zero cross scan delay (7.5deg)
 	sjmp	calc_new_wait_times_exit
 
 store_times_decrease_fast:
 	mov	Wt_Comm_Start_L, Temp1		; Now commutation time (~60deg) divided by 4 (~15deg nominal)
 	mov	Wt_Adv_Start_L, Temp3		; New commutation advance time (~15deg nominal)
-	mov	Wt_Zc_Scan_Start_L, Temp5	; Use this value for zero cross scan delay (7.5deg)
 
 calc_new_wait_times_exit:
 

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -1843,16 +1843,14 @@ calc_next_comm_new_period_div_done:
 	mov	Temp4, A
 	mov	Comm_Period4x_L, Temp3		; Store Comm_Period4x_X
 	mov	Comm_Period4x_H, Temp4
-	jnc	calc_new_wait_times_setup	; If period larger than 0xffff - go to slow case
-
-	mov	Temp4, #0FFh
-	mov	Comm_Period4x_L, Temp4		; Set commutation period registers to very slow timing (0xffff)
-	mov	Comm_Period4x_H, Temp4
+	jnc	calc_new_wait_times_setup	; Is period larger than 0xffff?
+	mov	Comm_Period4x_L, #0FFh		; Yes - Set commutation period registers to very slow timing (0xffff)
+	mov	Comm_Period4x_H, #0FFh
 
 calc_new_wait_times_setup:
 	; Set high rpm flag (if above 156k erpm)
 	clr	C
-	mov	A, Temp4
+	mov	A, Comm_Period4x_H
 	subb	A, #2					; Is Comm_Period4x_H below 2?
 	jnc	($+4)
 	setb	Flag_High_Rpm				; Yes - Set high rpm flag

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -1764,25 +1764,12 @@ calc_next_comm_startup_no_X:
 	mov	Temp2, A
 
 calc_next_comm_startup_average:
-	clr	C
-	mov	A, Comm_Period4x_H			; Average with previous and save
-	rrc	A
-	mov	Temp4, A
-	mov	A, Comm_Period4x_L
-	rrc	A
-	mov	Temp3, A
-	mov	A, Temp1
-	add	A, Temp3
-	mov	Comm_Period4x_L, A
-	mov	A, Temp2
-	addc	A, Temp4
-	mov	Comm_Period4x_H, A
-	jnc	($+8)
+	mov	Temp3, Comm_Period4x_L		; Comm_Period4x holds the time of 4 commutations
+	mov	Temp4, Comm_Period4x_H
+	mov	Temp7, #2
+	mov	Temp8, #0
+	sjmp	calc_next_comm_avg_period_div
 
-	mov	Comm_Period4x_L, #0FFh
-	mov	Comm_Period4x_H, #0FFh
-
-	sjmp	calc_new_wait_times_setup
 
 calc_next_comm_normal:
 	; Prepare averaging by dividing Comm_Period4x and current commutation period (Temp2/1) according to speed.

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -1875,7 +1875,7 @@ calc_next_comm_normal:
 calc_next_comm_div_4_1:
 	; Update Comm_Period4x from 1 new commutation period
 
-	; Divide by 4 and store in Temp6/Temp5
+	; Divide Temp4/3 by 4 and store in Temp6/5
 	Divide_By_4	Temp4, Temp3, Temp6, Temp5
 
 	sjmp	calc_next_comm_average_and_update
@@ -1883,7 +1883,7 @@ calc_next_comm_div_4_1:
 calc_next_comm_div_8_2:
 	; Update Comm_Period4x from 1/2 new commutation period
 
-	; Divide by 8 and store in Temp5
+	; Divide Temp4/3 by 8 and store in Temp5
 	Divide_11Bit_By_8	Temp4, Temp3, Temp5
 	mov	Temp6, #0
 
@@ -1896,7 +1896,7 @@ calc_next_comm_div_8_2:
 calc_next_comm_div_8_2_slow:
 	; Update Comm_Period4x from 1/2 new commutation period
 
-	; Divide by 8 and store in Temp6/Temp5
+	; Divide Temp4/3 by 8 and store in Temp6/5
 	Divide_By_8	Temp4, Temp3, Temp6, Temp5
 
 	clr	C						; Divide by 2
@@ -1908,14 +1908,17 @@ calc_next_comm_div_8_2_slow:
 calc_next_comm_div_16_4:
 	; Update Comm_Period4x from 1/4 new commutation period
 
-	; Divide by 16 and store in Temp5
+	; Divide Temp4/3 by 16 and store in Temp5
 	Divide_12Bit_By_16	Temp4, Temp3, Temp5
 	mov	Temp6, #0
 
-	; Divide by 4 and store in Temp2/Temp1
+	; Divide Temp2/1 by 4 and store in Temp2/1
 	Divide_By_4	Temp2, Temp1, Temp2, Temp1
 
 calc_next_comm_average_and_update:
+ 	; Comm_Period4x = Comm_Period4x - (Comm_Period4x / (16, 8 or 4)) + (Comm_Period / (4, 2 or 1))
+
+	; Temp6/5: Comm_Period4x divided by (16, 8 or 4)
 	clr	C						; Subtract a fraction
 	mov	A, Temp3					; Comm_Period4x_L
 	subb	A, Temp5
@@ -1924,6 +1927,7 @@ calc_next_comm_average_and_update:
 	subb	A, Temp6
 	mov	Temp4, A
 
+	; Temp2/1: This commutation period divided by (4, 2 or 1)
 	mov	A, Temp3					; Add the divided new time
 	add	A, Temp1
 	mov	Comm_Period4x_L, A
@@ -1975,7 +1979,7 @@ load_comm_timing_setting:
 	mov	Temp8, #5					; Set timing to max (if timing 6 or above)
 
 calc_next_comm_15deg:
-	; Commutation period: 60 deg / 6 runs = 60 deg
+	; Commutation period: 360 deg / 6 runs = 60 deg
 	; 60 deg / 4 = 15 deg
 
 	; Load current commutation timing and compute 15 deg timing

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -1817,14 +1817,6 @@ calc_next_comm_avg_period_div:
 	rrca	Temp5
 	djnz	Temp7, calc_next_comm_avg_period_div
 
-	clr	C
-	mov	A, Temp3
-	subb	A, Temp5					; Subtract a fraction
-	mov	Temp3, A
-	mov	A, Temp4
-	subb	A, Temp6
-	mov	Temp4, A
-
 	mov	A, Temp8					; Divide new time
 	jz	calc_next_comm_new_period_div_done
 
@@ -1835,6 +1827,14 @@ calc_next_comm_new_period_div:
 	djnz	Temp8, calc_next_comm_new_period_div
 
 calc_next_comm_new_period_div_done:
+	clr	C
+	mov	A, Temp3
+	subb	A, Temp5					; Subtract a fraction
+	mov	Temp3, A
+	mov	A, Temp4
+	subb	A, Temp6
+	mov	Temp4, A
+
 	mov	A, Temp3
 	add	A, Temp1					; Add the divided new time
 	mov	Comm_Period4x_L, A

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -1748,9 +1748,9 @@ ENDIF
 	jz	calc_next_comm_startup_no_X
 
 	; Extended byte is not zero, so commutation time is above 0xFFFF
-	mov	Temp1, #0FFh
-	mov	Temp2, #0FFh
-	sjmp	calc_next_comm_startup_average
+	mov	Comm_Period4x_L, #0FFh
+	mov	Comm_Period4x_H, #0FFh
+	sjmp	calc_new_wait_times_setup
 
 calc_next_comm_startup_no_X:
 	; Extended byte = 0, so commutation time fits within two bytes
@@ -1768,13 +1768,11 @@ calc_next_comm_startup_no_X:
 	subb	A, Temp8
 	mov	Temp2, A
 
-calc_next_comm_startup_average:
 	mov	Temp3, Comm_Period4x_L		; Comm_Period4x holds the time of 4 commutations
 	mov	Temp4, Comm_Period4x_H
 	mov	Temp7, #2
 	mov	Temp8, #0
 	sjmp	calc_next_comm_avg_period_div
-
 
 calc_next_comm_normal:
 	; Prepare averaging by dividing Comm_Period4x and current commutation period (Temp2/1) according to speed.

--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -1893,24 +1893,24 @@ calc_new_wait_per_demag_done:
 	; Divide Comm_Period4x by 16 (Comm_Period1x divided by 4) and store in Temp4/3
 	mov	A, Comm_Period4x_H			; Divide by 16
 	swap	A
-	mov	Temp3, A
+	mov	Temp7, A
 	anl	A, #00Fh
-	mov	Temp2, A
-	mov	A, Temp3
+	mov	Temp4, A
+	mov	A, Temp7
 	anl	A, #0F0h
-	mov	Temp1, A
+	mov	Temp3, A
 	mov	A, Comm_Period4x_L
 	swap	A
 	anl	A, #00Fh
-	add	A, Temp1
-	mov	Temp1, A
+	add	A, Temp3
+	mov	Temp3, A
 
 	; Subtract timing reduction
 	clr	C
-	mov	A, Temp1
+	mov	A, Temp3
 	subb	A, #2				; Set timing reduction
 	mov	Temp3, A
-	mov	A, Temp2
+	mov	A, Temp4
 	subb	A, #0
 	mov	Temp4, A
 


### PR DESCRIPTION
Improvements and restructuring of the routines that calculates and updates the commutation period.

- Fixes some bugs for startup phase
- Skip redundant steps when possible
- Use specialized code macros instead of loops
- General assembly optimizations