### PR TITLE
Optimize PWM updates

### DIFF
--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -222,11 +222,6 @@ Wt_Zc_Tout_Start_H:			DS	1	; Timer 3 start point for zero cross scan timeout (hi
 Wt_Comm_Start_L:			DS	1	; Timer 3 start point from zero cross to commutation (lo byte)
 Wt_Comm_Start_H:			DS	1	; Timer 3 start point from zero cross to commutation (hi byte)
 
-Power_Pwm_Reg_L:			DS	1	; Power pwm register setting (lo byte)
-Power_Pwm_Reg_H:			DS	1	; Power pwm register setting (hi byte)
-Damp_Pwm_Reg_L:			DS	1	; Damping pwm register setting (lo byte)
-Damp_Pwm_Reg_H:			DS	1	; Damping pwm register setting (hi byte)
-
 Pwm_Limit:				DS	1	; Maximum allowed pwm (8-bit)
 Pwm_Limit_By_Rpm:			DS	1	; Maximum allowed pwm for low or high rpm (8-bit)
 Pwm_Limit_Beg:				DS	1	; Initial pwm limit (8-bit)
@@ -960,29 +955,23 @@ ENDIF
 t1_int_set_pwm_damp_set:
 ENDIF
 
-	mov	Power_Pwm_Reg_L, Temp2
-	mov	Power_Pwm_Reg_H, Temp3
-
-IF DEADTIME != 0
-	mov	Damp_Pwm_Reg_L, Temp4
-	mov	Damp_Pwm_Reg_H, Temp5
-ENDIF
-
-; Set power pwm auto-reload registers
+	; Note: Interrupts (of higher priority) are not explicitly disabled because
+	; int0 is already disabled and timer 0 is assumed to be disabled at this point
 IF PWM_BITS_H != 0
-	Set_Power_Pwm_Reg_L Power_Pwm_Reg_L
-	Set_Power_Pwm_Reg_H Power_Pwm_Reg_H
+	; Set power pwm auto-reload registers
+	Set_Power_Pwm_Reg_L	Temp2
+	Set_Power_Pwm_Reg_H	Temp3
 ELSE
-	Set_Power_Pwm_Reg_H Power_Pwm_Reg_L
+	Set_Power_Pwm_Reg_H Temp2
 ENDIF
 
 IF DEADTIME != 0
 	; Set damp pwm auto-reload registers
 	IF PWM_BITS_H != 0
-		Set_Damp_Pwm_Reg_L Damp_Pwm_Reg_L
-		Set_Damp_Pwm_Reg_H Damp_Pwm_Reg_H
+		Set_Damp_Pwm_Reg_L	Temp4
+		Set_Damp_Pwm_Reg_H	Temp5
 	ELSE
-		Set_Damp_Pwm_Reg_H Damp_Pwm_Reg_L
+		Set_Damp_Pwm_Reg_H	Temp4
 	ENDIF
 ENDIF
 

--- a/Common.inc
+++ b/Common.inc
@@ -165,49 +165,6 @@ ELSE
 ENDIF
 ENDM
 
-Clear_COVF_Interrupt MACRO
-	anl	PCA0PWM, #0DFh				;; Clear PCA cycle overflow flag
-ENDM
-
-Enable_COVF_Interrupt MACRO
-	orl	PCA0PWM, #40h				;; Enable PCA interrupt on cycle overflow
-ENDM
-
-Disable_COVF_Interrupt MACRO
-	anl	PCA0PWM, #0BFh				;; Disable PCA interrupt on cycle overflow
-ENDM
-
-IF DEADTIME == 0					; CCF interrupt is only used for DEADTIME == 0
-Clear_CCF_Interrupt MACRO
-	anl	PCA0CN0, #0FEh				;; Clear PCA capture/compare flag
-ENDM
-
-Enable_CCF_Interrupt MACRO
-	orl	PCA0CPM0, #01h				;; Enable PCA interrupt on capture/compare
-ENDM
-
-Disable_CCF_Interrupt MACRO
-	anl	PCA0CPM0, #0FEh			;; Disable PCA interrupt on capture/compare
-ENDM
-ENDIF
-
-Enable_PCA_Interrupt MACRO
-LOCAL pca_enabled set_pca_int_hi_pwm
-IF DEADTIME != 0
-	Enable_COVF_Interrupt
-ELSE
-	jnb	Flag_Low_Pwm_Power, set_pca_int_hi_pwm
-
-	Enable_COVF_Interrupt
-	sjmp	pca_enabled
-
-set_pca_int_hi_pwm:
-	Enable_CCF_Interrupt
-pca_enabled:
-ENDIF
-	orl	EIE1, #10h				;; Enable pca interrupts
-ENDM
-
 Set_MCU_Clk_24MHz MACRO
 	mov	CLKSEL, #13h				;; Set clock to 24MHz (Oscillator 1 divided by 2)
 


### PR DESCRIPTION
Optimize PWM updates by removing the PCA interrupt and updating the internal auto-reload registers directly.