### PR TITLE
Updated temperature check function.

### DIFF
--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -4126,7 +4126,6 @@ run5:
 ; Run 6 = B(p-on) + A(n-pwm) - comparator C evaluated
 ; Out_cC changes from high to low
 run6:
-	Start_Adc						; Start adc conversion
 	call	wait_for_comp_out_low
 ;		setup_comm_wait
 ;		evaluate_comparator_integrity

--- a/Layouts/Base.inc
+++ b/Layouts/Base.inc
@@ -317,6 +317,7 @@ $endif
 ;**** **** **** **** ****
 TEMP_LIMIT		EQU	49			; Temperature measurement ADC value for which main motor power is limited at 80degC (low byte, assuming high byte is 1)
 TEMP_LIMIT_STEP	EQU	9			; Temperature measurement ADC value increment for another 10degC
+TEMP_CHECK_RATE	EQU	8			; Temperature check rate
 
 Initialize_Adc MACRO
 	mov	REF0CN, #0Ch				;; Set vdd (3.3V) as reference. Enable temp sensor and bias

--- a/Layouts/Base.inc
+++ b/Layouts/Base.inc
@@ -317,7 +317,7 @@ $endif
 ;**** **** **** **** ****
 TEMP_LIMIT		EQU	49			; Temperature measurement ADC value for which main motor power is limited at 80degC (low byte, assuming high byte is 1)
 TEMP_LIMIT_STEP	EQU	9			; Temperature measurement ADC value increment for another 10degC
-TEMP_CHECK_RATE	EQU	8			; Temperature check rate
+TEMP_CHECK_RATE	EQU	64			; Temperature check rate
 
 Initialize_Adc MACRO
 	mov	REF0CN, #0Ch				;; Set vdd (3.3V) as reference. Enable temp sensor and bias


### PR DESCRIPTION
Motivation: This function is called during run6 stage. The old one changed pwm limit abruptly when temperature level was reached and it's counter reached 8, iotherwise it increased pwm limit by 16, even if counter was different to 8, which was a problem because in the worst case pwm limit was reduced to 128 to be again increased by 16 in the next counter values different to 8.
Improvement: Function counter now works in reverse from 8 to 0, only when counter is 0 function executes. Moreover when a temperature level is reached a pwm level checkpoint is set, and then pwm level is moved one unit at a time towards this setpoint. This means that pwm limit is not made abruptly. This is good because when pwm limit changes abruptly it causes motor stuttering forcing it to change speed in small intervals and a result more heat is produced both in the motor and the mosfets, causing the oposite effect the function should cause (lowering temperature).
You can see this feature working here: https://www.youtube.com/watch?v=wwUJM5_AF7A